### PR TITLE
Add option to disable all mappings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,17 @@ is used. If you like to use the first buffer (like :sbuffer does), configure:
 
     let g:EnhancedJumps_SwitchStrategy = 'first'
 
-If you do not want to override the built-in jump commands and use separate
-mappings, or change the special additional mappings, map your keys to the
-<Plug>... mapping targets _before_ sourcing the script (e.g. in your vimrc).
+To disable specific mappings, see the next section. If you want to disable all
+the mappings by the plugin, configure:
+
+    let g:EnhancedJumps_NoMappings = 1
+
+If you want to disable all the mappings by the plugin, set
+`g:EnhancedJumps_NoMappings` as mentioned above.
+If you do not want to override the built-in jump commands for specific mappings
+and use separate mappings, or change the special additional mappings, map your
+keys to the <Plug>... mapping targets _before_ sourcing the script (e.g. in
+your vimrc).
 
     nmap {          <Plug>EnhancedJumpsOlder
     nmap }          <Plug>EnhancedJumpsNewer

--- a/doc/EnhancedJumps.txt
+++ b/doc/EnhancedJumps.txt
@@ -150,10 +150,19 @@ is used. If you like to use the first buffer (like |:sbuffer| does), configure: 
     let g:EnhancedJumps_SwitchStrategy = 'first'
 <
 
+					      *g:EnhancedJumps_NoMappings*
+To disable specific mappings, see |EnhancedJumps-remap|. If you want to
+disable all the mappings by the plugin, configure: >
+    let g:EnhancedJumps_NoMappings = 1
+<
+
 							 *EnhancedJumps-remap*
-If you do not want to override the built-in jump commands and use separate
-mappings, or change the special additional mappings, map your keys to the
-<Plug>... mapping targets _before_ sourcing the script (e.g. in your |vimrc|). >
+If you want to disable all the mappings by the plugin, set
+|g:EnhancedJumps_NoMappings|.
+If you do not want to override the built-in jump commands for specific
+mappings and use separate mappings, or change the special additional mappings,
+map the keys you want to disable to the <Plug>... mapping targets _before_
+sourcing the script (e.g. in your |vimrc|). >
     nmap {          <Plug>EnhancedJumpsOlder
     nmap }          <Plug>EnhancedJumpsNewer
     nmap g{         <Plug>EnhancedJumpsLocalOlder

--- a/plugin/EnhancedJumps.vim
+++ b/plugin/EnhancedJumps.vim
@@ -30,6 +30,9 @@ endif
 if ! exists('g:EnhancedJumps_SwitchStrategy')
     let g:EnhancedJumps_SwitchStrategy = 'nearest'
 endif
+if ! exists('g:EnhancedJumps_NoMappings')
+    let g:EnhancedJumps_NoMappings = 0
+endif
 
 
 "- mappings -------------------------------------------------------------------
@@ -51,37 +54,39 @@ nnoremap <silent> <Plug>EnhancedJumpsFarChangeNewer         :<C-u>if ! EnhancedJ
 nnoremap <silent> <Plug>EnhancedJumpsFarFallbackChangeOlder :<C-u>if ! EnhancedJumps#Changes#Jump(0,1)<Bar>echoerr ingo#err#Get('EnhancedJumps')<Bar>endif<CR>
 nnoremap <silent> <Plug>EnhancedJumpsFarFallbackChangeNewer :<C-u>if ! EnhancedJumps#Changes#Jump(1,1)<Bar>echoerr ingo#err#Get('EnhancedJumps')<Bar>endif<CR>
 
-if ! hasmapto('<Plug>EnhancedJumpsOlder', 'n')
-    nmap <C-o> <Plug>EnhancedJumpsOlder
-endif
-if ! hasmapto('<Plug>EnhancedJumpsNewer', 'n')
-    nmap <C-i> <Plug>EnhancedJumpsNewer
-endif
-if ! hasmapto('<Plug>EnhancedJumpsLocalOlder', 'n')
-    nmap g<C-o> <Plug>EnhancedJumpsLocalOlder
-endif
-if ! hasmapto('<Plug>EnhancedJumpsLocalNewer', 'n')
-    nmap g<C-i> <Plug>EnhancedJumpsLocalNewer
-endif
-if ! hasmapto('<Plug>EnhancedJumpsRemoteOlder', 'n')
-    nmap <Leader><C-o> <Plug>EnhancedJumpsRemoteOlder
-endif
-if ! hasmapto('<Plug>EnhancedJumpsRemoteNewer', 'n')
-    nmap <Leader><C-i> <Plug>EnhancedJumpsRemoteNewer
-endif
+if ! g:EnhancedJumps_NoMappings
+    if ! hasmapto('<Plug>EnhancedJumpsOlder', 'n')
+        nmap <C-o> <Plug>EnhancedJumpsOlder
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsNewer', 'n')
+        nmap <C-i> <Plug>EnhancedJumpsNewer
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsLocalOlder', 'n')
+        nmap g<C-o> <Plug>EnhancedJumpsLocalOlder
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsLocalNewer', 'n')
+        nmap g<C-i> <Plug>EnhancedJumpsLocalNewer
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsRemoteOlder', 'n')
+        nmap <Leader><C-o> <Plug>EnhancedJumpsRemoteOlder
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsRemoteNewer', 'n')
+        nmap <Leader><C-i> <Plug>EnhancedJumpsRemoteNewer
+    endif
 
-if ! hasmapto('<Plug>EnhancedJumpsSwitchRemoteOlder', 'n')
-    nmap <Leader><C-w><C-o> <Plug>EnhancedJumpsSwitchRemoteOlder
-endif
-if ! hasmapto('<Plug>EnhancedJumpsSwitchRemoteNewer', 'n')
-    nmap <Leader><C-w><C-i> <Plug>EnhancedJumpsSwitchRemoteNewer
-endif
+    if ! hasmapto('<Plug>EnhancedJumpsSwitchRemoteOlder', 'n')
+        nmap <Leader><C-w><C-o> <Plug>EnhancedJumpsSwitchRemoteOlder
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsSwitchRemoteNewer', 'n')
+        nmap <Leader><C-w><C-i> <Plug>EnhancedJumpsSwitchRemoteNewer
+    endif
 
-if ! hasmapto('<Plug>EnhancedJumpsFarFallbackChangeOlder', 'n')
-    nmap g; <Plug>EnhancedJumpsFarFallbackChangeOlder
-endif
-if ! hasmapto('<Plug>EnhancedJumpsFarFallbackChangeNewer', 'n')
-    nmap g, <Plug>EnhancedJumpsFarFallbackChangeNewer
+    if ! hasmapto('<Plug>EnhancedJumpsFarFallbackChangeOlder', 'n')
+        nmap g; <Plug>EnhancedJumpsFarFallbackChangeOlder
+    endif
+    if ! hasmapto('<Plug>EnhancedJumpsFarFallbackChangeNewer', 'n')
+        nmap g, <Plug>EnhancedJumpsFarFallbackChangeNewer
+    endif
 endif
 
 " vim: set ts=8 sts=4 sw=4 noexpandtab ff=unix fdm=syntax :


### PR DESCRIPTION
It's already possible to disable specific mappings by doing "fake" mappings.
However, one advantage of having the new setting as a user is that you don't
have to worry about the exact remappings done by the plugin. You just define
what you need. Without this setting, the user needs to read the source (or check
:map after the plugin is loaded) to get the complete list of mappings done by
the plugin, and then manually unmap each one. And in principle, this should be
done every time the plugin is updated.